### PR TITLE
[bolt-run] adds support for downloading modules

### DIFF
--- a/bolt-run/docs/v1.md
+++ b/bolt-run/docs/v1.md
@@ -16,6 +16,7 @@ and the complete set of Bolt configuration via a Bolt project's `bolt.yaml` and
 | `parameters` || mapping | The task- or plan-specific parameter data to use for this run. | None | False |
 | `projectDir` || string | When the `git` setting is specified, the relative directory within the Git repository to use as the Bolt project. | `.` | False |
 | `modulePaths` || array | A list of additional directories outside of the project directory to add to the Bolt module path. | None | False |
+| `installModules` || boolean | Download and install modules listed in a `Puppetfile`. | `false` | False |
 | `transport` || mapping | The default transport to use when connecting to the target nodes. | None | False |
 || `type` | string | The transport type, one of `ssh` or `winrm`. | None | False |
 || `user` | string | The username to use to connect. | None | False |

--- a/bolt-run/step.sh
+++ b/bolt-run/step.sh
@@ -121,7 +121,7 @@ TARGETS="$( $NI get | $JQ -r 'try .targets | if type == "string" then . else joi
 
 INSTALL_MODULES="$( $NI get -p '{ .installModules }' )"
 if [[ "${INSTALL_MODULES}" == "true" ]]; then
-    $BOLT puppetfile install
+    $BOLT puppetfile install "${BOLT_ARGS[@]}"
 fi
 
 # Run Bolt!

--- a/bolt-run/step.sh
+++ b/bolt-run/step.sh
@@ -119,6 +119,11 @@ esac
 TARGETS="$( $NI get | $JQ -r 'try .targets | if type == "string" then . else join(",") end' )"
 [ -n "${TARGETS}" ] && BOLT_ARGS+=( "--targets=${TARGETS}" )
 
+INSTALL_MODULES="$( $NI get -p '{ .installModules }' )"
+if [[ "${INSTALL_MODULES}" == "true" ]]; then
+    $BOLT puppetfile install
+fi
+
 # Run Bolt!
 $BOLT \
   "${BOLT_TYPE}" run "${BOLT_NAME}" \


### PR DESCRIPTION
bolt-run currently doesn't support a Puppetfile containing the `mod`
directive to pull modules from the Forge. This PR adds support for
downloading and installing public modules from the Forge by allowing a
user to include a `Puppetfile` along side their `bolt.yaml` and then
setting `spec.installModules: true`.