### PR TITLE
Allow terraform step to accept commands

### DIFF
--- a/terraform/step.sh
+++ b/terraform/step.sh
@@ -55,7 +55,7 @@ declare -a BACKEND_CONFIGS="( $( $NI get | $JQ -r 'try .backendConfig | to_entri
 terraform init ${BACKEND_CONFIGS[@]}
 terraform workspace new ${WORKSPACE}
 terraform workspace select ${WORKSPACE}
-terraform apply -auto-approve
+terraform ${COMMAND} -auto-approve
 
 keys=$(terraform output -json | jq -r '. | keys | .[]')
 for key in ${keys}; do

--- a/terraform/step.sh
+++ b/terraform/step.sh
@@ -21,6 +21,7 @@ done
 
 DIRECTORY=$(ni get -p {.directory})
 WORKSPACE=$(ni get -p {.workspace})
+COMMAND=$(ni get -p {.command})
 WORKSPACE_FILE=workspace.${WORKSPACE}.tfvars.json
 
 CREDENTIALS=$(ni get -p {.credentials})

--- a/terraform/step.sh
+++ b/terraform/step.sh
@@ -22,6 +22,7 @@ done
 DIRECTORY=$(ni get -p {.directory})
 WORKSPACE=$(ni get -p {.workspace})
 COMMAND=$(ni get -p {.command})
+[ "$COMMAND" ] || COMMAND="apply"
 WORKSPACE_FILE=workspace.${WORKSPACE}.tfvars.json
 
 CREDENTIALS=$(ni get -p {.credentials})


### PR DESCRIPTION
Still apply by default, pass arbitrary command via -command
Example: https://github.com/timbortnik/nebula-workflow-examples/blob/master/example-workflows/gke-provision-and-deploy-workflow/gke-provision-and-deploy-workflow.yaml